### PR TITLE
Allow custom host/port

### DIFF
--- a/rmq.nim
+++ b/rmq.nim
@@ -1,12 +1,13 @@
 import asyncdispatch, logging, net
 import rmqsrc/[connection, events]
+import parseopt2
+from strutils import parseInt
 
 addHandler newConsoleLogger()
 
-when isMainModule:
-  # user:user@192.168.111.222:5672
+proc main(host: string, port: int) =
   var
-    params = (host: "192.168.111.222", port: 5672)
+    params = (host: host, port: port)
     c = newConnection(params)
 
   connect(c)
@@ -16,6 +17,24 @@ when isMainModule:
 
   waitFor c.handleEvents()
 
-  assert (not c.framesWaiting)
+  assert(not c.framesWaiting)
 
   info "Connection diagnostics: " & $c.diagnostics
+
+when isMainModule:
+  var
+    host = "192.168.111.222"
+    port = 5672
+
+  for kind, key, value in getopt():
+    case kind
+    of cmdLongOption:
+      case key
+      of "host":
+        host = value
+      of "port":
+        port = parseInt(value)
+    else:
+      continue
+
+  main(host, port)


### PR DESCRIPTION
Strictly for convenience. Allow users to pass in host/post via `--host=HOST --port=PORT`
  