### PR TITLE
Update StartOk parameters

### DIFF
--- a/rmq.nim
+++ b/rmq.nim
@@ -31,6 +31,10 @@ when isMainModule:
         host = value
       of "port":
         port = parseInt(value)
+      of "user":
+        username = value
+      of "password":
+        password = value
     else:
       continue
 

--- a/rmqsrc/connections.nim
+++ b/rmqsrc/connections.nim
@@ -222,8 +222,8 @@ proc sendConnectionStartOk(connection: Connection, connectionStartFrame: Frame, 
         class: cConnection,
         kind: mStartOk,
         mStartOkParams: (
-          connectionStartFrame.rpcMethod.mStartParams.serverProperties,
-          connectionStartFrame.rpcMethod.mStartParams.mechanisms,
+          initTable[string, ValueNode](),   # Default client params is nothing
+          "PLAIN",
           response,
           connectionStartFrame.rpcMethod.mStartParams.locales
         )
@@ -259,7 +259,7 @@ proc onConnectionStart(connection: Connection, methodFrame: Frame) =
   # self._add_connection_tune_callback()
 
   # TODO parametrize connection start response string?
-  connection.sendConnectionStartOk(methodFrame, "Connection received")
+  connection.sendConnectionStartOk(methodFrame, connection.getCredentials(methodFrame))
 
 proc onConnected(connection: Connection) =
   connection.state = csProtocol

--- a/tests.nim
+++ b/tests.nim
@@ -72,7 +72,7 @@ suite "connection tests":
     check(not c.bufferRemaining)
 
     let diagnostics = c.diagnostics
-    check (493, 1, 494, 1) == diagnostics
+    check (34, 1, 494, 1) == diagnostics
     check 7 == c.serverProperties.len
     check csStart == c.state
     check 9 == c.serverProperties["capabilities"].keys.len
@@ -87,13 +87,12 @@ suite "encoding test":
       f = Frame()
 
     m.kind = mStartOk
-    m.mStartOkParams = (initTable[string, ValueNode](),"PLAIN", "hi", "en_US")
+    m.mStartOkParams = (initTable[string, ValueNode](),"PLAIN", "userpassword", "en_US")
 
     f.channelNumber = 1.uint16
     f.kind = fkMethod
     f.rpcMethod = m
 
-    const byteseq = @['\x01', '\x00', '\x01', '\x00', '\x00', '\x00', '\x1A', '\x00', '\x0A', '\x00', '\x0B', '\x00', '\x00', '\x00', '\x00', '\x05', 'P', 'L', 'A', 'I', 'N', '\x00', '\x00', '\x00', '\x02', 'h', 'i', '\x05', 'e', 'n', '_', 'U', 'S', '\xCE']
+    const byteseq = @['\x01', '\x00', '\x01', '\x00', '\x00', '\x00', '$', '\x00', '\x0A', '\x00', '\x0B', '\x00', '\x00', '\x00', '\x00', '\x05', 'P', 'L', 'A', 'I', 'N', '\x00', '\x00', '\x00', '\x0C', 'u', 's', 'e', 'r', 'p', 'a', 's', 's', 'w', 'o', 'r', 'd', '\x05', 'e', 'n', '_', 'U', 'S', '\xCE']
 
     check f.marshal() == byteseq.join()
-


### PR DESCRIPTION
There was no encoding error, but the parameters I was passing in were wrong in a few ways:
* `serverProperties` should be empty by default (when provided by the client)
* `mechanisms` should be `PLAIN`
* `response` must be the username and password, not just some random text like i had before...