### PR TITLE
Method lookup table

### DIFF
--- a/rmq.nim
+++ b/rmq.nim
@@ -31,6 +31,10 @@ when isMainModule:
         host = value
       of "port":
         port = parseInt(value)
+      of "user":
+        username = value
+      of "password":
+        password = value
     else:
       continue
 

--- a/rmqsrc/connections.nim
+++ b/rmqsrc/connections.nim
@@ -222,8 +222,8 @@ proc sendConnectionStartOk(connection: Connection, connectionStartFrame: Frame, 
         class: cConnection,
         kind: mStartOk,
         mStartOkParams: (
-          connectionStartFrame.rpcMethod.mStartParams.serverProperties,
-          connectionStartFrame.rpcMethod.mStartParams.mechanisms,
+          initTable[string, ValueNode](),   # Default client params is nothing
+          "PLAIN",
           response,
           connectionStartFrame.rpcMethod.mStartParams.locales
         )
@@ -259,7 +259,7 @@ proc onConnectionStart(connection: Connection, methodFrame: Frame) =
   # self._add_connection_tune_callback()
 
   # TODO parametrize connection start response string?
-  connection.sendConnectionStartOk(methodFrame, "Connection received")
+  connection.sendConnectionStartOk(methodFrame, connection.getCredentials(methodFrame))
 
 proc onConnected(connection: Connection) =
   connection.state = csProtocol

--- a/rmqsrc/decode.nim
+++ b/rmqsrc/decode.nim
@@ -22,8 +22,8 @@ proc readBigEndian16(s: Stream): int16 =
   result = s.readInt16
   bigEndian16(addr result, addr result)
 
-proc readClassId(s: Stream): auto = readBigEndian16(s)
-proc readMethodId(s: Stream): auto = readBigEndian16(s)
+proc readClassId(s: Stream): auto = readBigEndianU16(s)
+proc readMethodId(s: Stream): auto = readBigEndianU16(s)
 
 proc readBigEndianU32(s: Stream): uint32 =
   result = s.readUInt32
@@ -200,11 +200,17 @@ proc decodeConnectionStart(data: Stream): Method =
 
 proc decodeMethod(data: Stream): Method =
   let
-    class = data.readClassId.Class
-    methodId = data.readMethodId.MethodId
+    classNum = data.readClassId
+    methodNum = data.readMethodId
+
+  let
+    pair = toMethod(classNum, methodNum)
+    class = pair[0]
+    methodId = pair[1]
+
   case methodId
   of mStart: data.decodeConnectionStart()
-  else: Method(class: class)
+  else: raise newException(ValueError, "Cannot decode Method ID: $#" % [$methodId])
 
 proc decode*(data: string): DecodedFrame =
   if data.startsWith("AMQP"):

--- a/rmqsrc/decode.nim
+++ b/rmqsrc/decode.nim
@@ -203,10 +203,7 @@ proc decodeMethod(data: Stream): Method =
     classNum = data.readClassId
     methodNum = data.readMethodId
 
-  let
-    pair = toMethod(classNum, methodNum)
-    class = pair[0]
-    methodId = pair[1]
+  let (_, methodId) = toMethod(classNum, methodNum)
 
   case methodId
   of mStart: data.decodeConnectionStart()

--- a/rmqsrc/encode.nim
+++ b/rmqsrc/encode.nim
@@ -58,9 +58,9 @@ proc encode*(params: varargs[ValueNode]): seq[char] =
 proc encode*(m: Method): seq[char] =
   result = newSeq[char]()
 
-  let pair = fromMethod(m.class, m.kind)
-  result &= pair[0].encode()
-  result &= pair[1].encode()
+  let (classId, methodId) = fromMethod(m.class, m.kind)
+  result &= classId.encode()
+  result &= methodId.encode()
 
   case m.kind
   of mStartOk:

--- a/rmqsrc/encode.nim
+++ b/rmqsrc/encode.nim
@@ -58,8 +58,9 @@ proc encode*(params: varargs[ValueNode]): seq[char] =
 proc encode*(m: Method): seq[char] =
   result = newSeq[char]()
 
-  result &= m.class.uint16.encode()
-  result &= m.kind.uint16.encode()
+  let pair = fromMethod(m.class, m.kind)
+  result &= pair[0].encode()
+  result &= pair[1].encode()
 
   case m.kind
   of mStartOk:

--- a/rmqsrc/spec.nim
+++ b/rmqsrc/spec.nim
@@ -1,27 +1,30 @@
+import tables, sequtils, strutils
+
 type
   ChannelNumber* = uint16
   Class* = enum
-    cNull = 0,        # For discriminant
-    cConnection = 10, # work with socket connections
-    cChannel = 20,    # work with channels
-    cExchange = 30,   # work with exchanges
-    cQueue = 40,      # work with exchanges
-    cBasic = 50       # work with basic content
+    cNull,        # For discriminant
+    cConnection,  # work with socket connections
+    cChannel,     # work with channels
+    cExchange,    # work with exchanges
+    cQueue,       # work with exchanges
+    cBasic        # work with basic content
 
   MethodId* = enum
-    mNull = 0,        # For discriminant
-    mStart = 10,      # start connection negotiation
-    mStartOk = 11,    # select security mechanism and locale
-    mSecure = 20,     # security mechanism challenge
-    mSecureOk = 21,   # security mechanism response
-    mTune = 30,       # propose connection tuning parameters
-    mTuneOk = 31,     # negotiate connection tuning parameters
-    mOpen = 40,       # open connection to virtual host
-    mOpenOk = 41,     # signal that connection is ready
-    mClose = 50,      # request a connection close
-    mCloseOk = 51     # confirm a connection close
+    mNull,        # For discriminant
+    mStart,       # start connection negotiation
+    mStartOk,     # select security mechanism and locale
+    mSecure,      # security mechanism challenge
+    mSecureOk,    # security mechanism response
+    mTune,        # propose connection tuning parameters
+    mTuneOk,      # negotiate connection tuning parameters
+    mOpen,        # open connection to virtual host
+    mOpenOk,      # signal that connection is ready
+    mClose,       # request a connection close
+    mCloseOk      # confirm a connection close
 
 # TODO add more methods
+
 const
   VERSION_MAJOR* = 0.char
   VERSION_MINOR* = 9.char
@@ -33,3 +36,29 @@ const
 
   FRAME_MAX_SIZE* = 131072
   BODY_MAX_LENGTH* = FRAME_MAX_SIZE - FRAME_HEADER_SIZE - FRAME_END_SIZE
+
+let
+  METHODS = {
+    (10.uint16, 10.uint16): (cConnection, mStart),       # start connection negotiation
+    (10.uint16, 11.uint16): (cConnection, mStartOk),     # select security mechanism and locale
+    (10.uint16, 20.uint16): (cConnection, mSecure),      # security mechanism challenge
+    (10.uint16, 21.uint16): (cConnection, mSecureOk),    # security mechanism response
+    (10.uint16, 30.uint16): (cConnection, mTune),        # propose connection tuning parameters
+    (10.uint16, 31.uint16): (cConnection, mTuneOk),      # negotiate connection tuning parameters
+    (10.uint16, 40.uint16): (cConnection, mOpen),        # open connection to virtual host
+    (10.uint16, 41.uint16): (cConnection, mOpenOk),      # signal that connection is ready
+    (10.uint16, 50.uint16): (cConnection, mClose),       # request a connection close
+    (10.uint16, 51.uint16): (cConnection, mCloseOk)      # confirm a connection close
+  }.toTable
+
+  METHOD_VALS = toSeq(METHODS.pairs).mapIt((it[1], it[0])).toTable
+
+proc toMethod*(cNum: uint16, mNum: uint16): (Class, MethodId)  =
+  if not METHODS.hasKey((cNum, mNum)):
+    raise newException(KeyError, "No method for Class ID: $# and Method ID: $#" % [$cNum, $mNum])
+  return METHODS[(cNum, mNum)]
+
+proc fromMethod*(c: Class, m: MethodId): (uint16, uint16) =
+  if not METHOD_VALS.hasKey((c, m)):
+    raise newException(KeyError, "No value for Class: $# and Method: $#" % [$c, $m])
+  return METHOD_VALS[(c, m)]

--- a/rmqsrc/spec.nim
+++ b/rmqsrc/spec.nim
@@ -54,11 +54,13 @@ let
   METHOD_VALS = toSeq(METHODS.pairs).mapIt((it[1], it[0])).toTable
 
 proc toMethod*(cNum: uint16, mNum: uint16): (Class, MethodId)  =
-  if not METHODS.hasKey((cNum, mNum)):
+  let key = (cnUm, mNum)
+  if key notin METHODS:
     raise newException(KeyError, "No method for Class ID: $# and Method ID: $#" % [$cNum, $mNum])
-  return METHODS[(cNum, mNum)]
+  return METHODS[key]
 
 proc fromMethod*(c: Class, m: MethodId): (uint16, uint16) =
-  if not METHOD_VALS.hasKey((c, m)):
+  let key = (c, m)
+  if key notin METHOD_VALS:
     raise newException(KeyError, "No value for Class: $# and Method: $#" % [$c, $m])
-  return METHOD_VALS[(c, m)]
+  return METHOD_VALS[key]

--- a/tests.nim
+++ b/tests.nim
@@ -72,7 +72,7 @@ suite "connection tests":
     check(not c.bufferRemaining)
 
     let diagnostics = c.diagnostics
-    check (493, 1, 494, 1) == diagnostics
+    check (34, 1, 494, 1) == diagnostics
     check 7 == c.serverProperties.len
     check csStart == c.state
     check 9 == c.serverProperties["capabilities"].keys.len
@@ -87,13 +87,12 @@ suite "encoding test":
       f = Frame()
 
     m.kind = mStartOk
-    m.mStartOkParams = (initTable[string, ValueNode](),"PLAIN", "hi", "en_US")
+    m.mStartOkParams = (initTable[string, ValueNode](),"PLAIN", "userpassword", "en_US")
 
     f.channelNumber = 1.uint16
     f.kind = fkMethod
     f.rpcMethod = m
 
-    const byteseq = @['\x01', '\x00', '\x01', '\x00', '\x00', '\x00', '\x1A', '\x00', '\x0A', '\x00', '\x0B', '\x00', '\x00', '\x00', '\x00', '\x05', 'P', 'L', 'A', 'I', 'N', '\x00', '\x00', '\x00', '\x02', 'h', 'i', '\x05', 'e', 'n', '_', 'U', 'S', '\xCE']
+    const byteseq = @['\x01', '\x00', '\x01', '\x00', '\x00', '\x00', '$', '\x00', '\x0A', '\x00', '\x0B', '\x00', '\x00', '\x00', '\x00', '\x05', 'P', 'L', 'A', 'I', 'N', '\x00', '\x00', '\x00', '\x0C', 'u', 's', 'e', 'r', 'p', 'a', 's', 's', 'w', 'o', 'r', 'd', '\x05', 'e', 'n', '_', 'U', 'S', '\xCE']
 
     check f.marshal() == byteseq.join()
-


### PR DESCRIPTION
This branch is rebased from `fix-start-ok`, so make that one gets merged in first.

With this change Class/Method enum values are no longer significant. This unblocks us from adding Methods from the AMQP spec that have the same Method IDs.